### PR TITLE
add alignment icons on text box

### DIFF
--- a/icons.js
+++ b/icons.js
@@ -1,0 +1,9 @@
+export const textLeft =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 333 333'%3E%3Cdefs/%3E%3Cpath d='M323 32H10C5 32 0 36 0 42s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM230 115H10c-5 0-10 4-10 10s5 10 10 10h220c6 0 10-5 10-10s-4-10-10-10zM323 199H10c-5 0-10 4-10 10s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM151 282H10c-5 0-10 4-10 10s5 10 10 10h141c6 0 10-5 10-10s-4-10-10-10z'/%3E%3C/svg%3E";
+export const textRight =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 333 333'%3E%3Cdefs/%3E%3Cpath d='M323 32H10C5 32 0 36 0 42s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM323 115H104c-5 0-10 4-10 10s5 10 10 10h219c6 0 10-5 10-10s-4-10-10-10zM323 199H10c-5 0-10 4-10 10s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM323 282H182c-5 0-10 4-10 10s5 10 10 10h141c6 0 10-5 10-10s-4-10-10-10z'/%3E%3C/svg%3E";
+
+export const textCenter =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 333 333'%3E%3Cdefs/%3E%3Cpath d='M323 32H10C5 32 0 36 0 42s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM276 115H56c-5 0-10 4-10 10s5 10 10 10h220c6 0 10-5 10-10s-4-10-10-10zM323 199H10c-5 0-10 4-10 10s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM234 282H93c-5 0-10 4-10 10s5 10 10 10h141c6 0 10-5 10-10s-4-10-10-10z'/%3E%3C/svg%3E";
+export const textJustify =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 333 333'%3E%3Cdefs/%3E%3Cpath d='M323 32H10C5 32 0 36 0 42s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM323 115H10c-5 0-10 4-10 10s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM323 199H10c-5 0-10 4-10 10s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10zM323 282H10c-5 0-10 4-10 10s5 10 10 10h313c6 0 10-5 10-10s-4-10-10-10z'/%3E%3C/svg%3E";


### PR DESCRIPTION
Implemented text alignment with controls placed inside the canvas, on top of text box.
just thought it could work better for the design, because it's only text-specific feature. But of course it's easy to put back into the toolbar, if we want.
Demo updated: https://illustrova.github.io/canvas-editor-experiment/
